### PR TITLE
use a more generic makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,28 +3,28 @@ dist: trusty
 language: c
 matrix:
    include:
-     - addons: 
+     - addons:
           postgresql: 9.3
        env:
           - POSTGRESQL=9.3
        install:
            - sudo apt-get install postgresql-server-dev-9.3
            - make && sudo make install
-     - addons: 
+     - addons:
           postgresql: 9.4
        env:
           - POSTGRESQL=9.4
        install:
            - sudo apt-get install postgresql-server-dev-9.4
            - make && sudo make install
-     - addons: 
+     - addons:
           postgresql: 9.5
        install:
            - sudo apt-get install postgresql-server-dev-9.5
            - make && sudo make install
        env:
           - POSTGRESQL=9.5
-     - addons: 
+     - addons:
           postgresql: 9.6
        install:
            - sudo apt-get install postgresql-server-dev-9.6
@@ -48,8 +48,7 @@ matrix:
    allow_failures:
     - addons:
         postgresql: 9.3
-    - addons:
-        postgresql: 9.4
+
 script:
   - make installcheck
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,26 +9,22 @@ matrix:
           - POSTGRESQL=9.3
        install:
            - sudo apt-get install postgresql-server-dev-9.3
-           - make && sudo make install
      - addons:
           postgresql: 9.4
        env:
           - POSTGRESQL=9.4
        install:
            - sudo apt-get install postgresql-server-dev-9.4
-           - make && sudo make install
      - addons:
           postgresql: 9.5
        install:
            - sudo apt-get install postgresql-server-dev-9.5
-           - make && sudo make install
        env:
           - POSTGRESQL=9.5
      - addons:
           postgresql: 9.6
        install:
            - sudo apt-get install postgresql-server-dev-9.6
-           - make && sudo make install
        env:
           - POSTGRESQL=9.6
      - # addons: postgresql: 10
@@ -42,7 +38,6 @@ matrix:
            - sudo sh -c 'echo "port=5432" >> /etc/postgresql/10/main/postgresql.conf'
            - sudo pg_ctlcluster 10 main restart
            - sudo -u postgres psql  -c "create user travis with superuser";
-           - make && sudo make install
        env:
           - POSTGRESQL=10
    allow_failures:
@@ -50,6 +45,7 @@ matrix:
         postgresql: 9.3
 
 script:
+  - make && sudo make install 
   - make installcheck
 after_failure:
   - cat regression.diffs

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: $(EXTENSION)--$(EXTVERSION).sql
 
 $(EXTENSION)--$(EXTVERSION).sql: $(wildcard sql/*.sql)
 	echo "-- complain if script is sourced in psql, rather than via CREATE EXTENSION" > $@
-	echo "\echo Use \"CREATE EXTENSION istore\" to load this file. \quit" >> $@
+	echo "\echo Use \"CREATE EXTENSION ${EXTENSION}\" to load this file. \quit" >> $@
 	echo "" >> $@
 	cat $^ >> $@
 

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,27 @@
 EXTENSION = language
 EXTVERSION = $(shell grep default_version $(EXTENSION).control | \
                 sed -e "s/default_version[[:space:]]*=[[:space:]]*'\([^']*\)'/\1/")
-DATA = $(wildcard sql/*--*.sql)
+DATA = $(wildcard *--*.sql)
 
 MODULE_big = language
-OBJS = src/language.o
+OBJS = $(patsubst %.c,%.o,$(wildcard src/*.c))
 EXTRA_CLEAN = src/language_reverse.h src/language_forward.h
-
-REGRESS_OPTS_EXTRA ?= --temp-instance=$$PWD/tmp
 
 TESTS        = $(wildcard test/sql/*.sql)
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
-REGRESS_OPTS = --inputdir=test --load-extension=${EXTENSION} ${REGRESS_OPTS_EXTRA}
+REGRESS_OPTS = --inputdir=test --load-extension=${EXTENSION}
 
-all: concat
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+
+all: $(EXTENSION)--$(EXTVERSION).sql
+
+$(EXTENSION)--$(EXTVERSION).sql: $(wildcard sql/*.sql)
+	echo "-- complain if script is sourced in psql, rather than via CREATE EXTENSION" > $@
+	echo "\echo Use \"CREATE EXTENSION istore\" to load this file. \quit" >> $@
+	echo "" >> $@
+	cat $^ >> $@
 
 src/language.o: ${EXTRA_CLEAN}
 
@@ -23,11 +31,5 @@ src/language_reverse.h: languages src/lang_rev.awk
 src/language_forward.h: languages src/lang_fwd.awk
 	sort -k 3 -n $< | awk -f src/lang_fwd.awk > $@
 
-concat:
-	echo > sql/$(EXTENSION)--$(EXTVERSION).sql
-	cat $(filter-out $(wildcard sql/*--*.sql),$(wildcard sql/*.sql)) >> sql/$(EXTENSION)--$(EXTVERSION).sql
 
 
-PG_CONFIG = pg_config
-PGXS := $(shell $(PG_CONFIG) --pgxs)
-include $(PGXS)

--- a/language--0.0.1.sql
+++ b/language--0.0.1.sql
@@ -1,3 +1,6 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION istore" to load this file. \quit
+
 CREATE TYPE language;
 
 CREATE FUNCTION supported_languages()

--- a/language.control
+++ b/language.control
@@ -1,5 +1,6 @@
 # currency extension
 comment = 'Custom PostgreSQL language enumeration type'
 default_version = '0.0.1'
+module_pathname = '$libdir/language'
 relocatable = true
 requires = ''


### PR DESCRIPTION
* moves the  extensions sql files into the top directory
  and checks them into version control.
* avoids loading the sql file as script rather than CREATE EXTENSION
* `module_pathname` is added to the `.control` file
  so that `MODULE_PATHNAME` can be used to refer to the library
* OBJS beeing more generic
* disallow failure against pg 9.4 on travis
* build against runnig postgres